### PR TITLE
add hot export to pages and sidebar component

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -22,7 +22,7 @@ module.exports = {
       }
     },
     devServer: {
-      hot: true
+      hotOnly: true
     }
   },
   babel: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "@craco/craco": "^3.4.1",
-    "@hot-loader/react-dom": "^16.8.1",
+    "@hot-loader/react-dom": "^16.8.4",
     "@makerdao/dai": "^0.10.0",
     "@makerdao/dai-plugin-config": "^0.0.2",
     "@makerdao/dai-plugin-ledger-web": "^0.9.7",
@@ -31,7 +31,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-ga": "^2.5.7",
-    "react-hot-loader": "^4.6.5",
+    "react-hot-loader": "^4.8.0",
     "react-icons": "^3.4.0",
     "react-localization": "^1.0.13",
     "react-navi": "^0.10.6",

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import styled, { ThemeProvider } from 'styled-components';
 import { NavProvider, NavContent, NavNotFoundBoundary } from 'react-navi';
-import { hot } from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import { GenericNotFound } from 'pages/NotFound';
 import store from './store';
 import theme from 'styles/theme';
@@ -38,4 +38,4 @@ function AppWithContext({ navigation }) {
   );
 }
 
-export default hot(module)(AppWithContext);
+export default hot(AppWithContext);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader/root';
 import { getAllFeeds } from 'reducers/network/cdpTypes';
 
 import { Flex, Text } from '@makerdao/ui-components-core';
@@ -109,4 +110,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(Sidebar);
+export default hot(connect(mapStateToProps)(Sidebar));

--- a/src/pages/CDP.js
+++ b/src/pages/CDP.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { hot } from 'react-hot-loader/root';
 import PageContentLayout from 'layouts/PageContentLayout';
 import lang from 'languages';
 import { Box } from '@makerdao/ui-components-core';
@@ -79,4 +80,4 @@ function CDPView({ cdpTypeSlug }) {
   );
 }
 
-export default CDPView;
+export default hot(CDPView);

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { hot } from 'react-hot-loader/root';
 import Footer from '@makerdao/ui-components-footer';
 import Header from '@makerdao/ui-components-header';
 import { Box } from '@makerdao/ui-components-core';
@@ -52,4 +53,4 @@ function Landing() {
   );
 }
 
-export default Landing;
+export default hot(Landing);

--- a/src/pages/Overview.js
+++ b/src/pages/Overview.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { hot } from 'react-hot-loader/root';
 import PageContentLayout from 'layouts/PageContentLayout';
 import lang from 'languages';
 import { Heading } from 'components/Typography';
@@ -14,4 +15,4 @@ function Overview() {
   );
 }
 
-export default Overview;
+export default hot(Overview);

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,15 +892,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
   integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
-"@hot-loader/react-dom@^16.8.1":
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.3.tgz#eda02b457b2d1dea2d107f4b63e0b9723b88e775"
-  integrity sha512-1qsW26XvHyvl5DswKqOYzG7PefYVaauwl3KM5Eb6MjYsF3TH4CcZ/TTcStscsRrde+2B4oXcWOTzFc5nI0ArLg==
+"@hot-loader/react-dom@^16.8.4":
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.4.tgz#aefe598ca26005c1ec3ac11d92d54ff3c1cd219c"
+  integrity sha512-S+5x4HJEMV7p2FzgUBEzrgiNJJeN4m5auTL3rZbmGsuyGt3Tgg8zgz6Mt1Udj8dKDxaryixDSNh0d/63TMqizg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.3"
+    scheduler "^0.13.4"
 
 "@ledgerhq/devices@^4.43.0":
   version "4.43.0"
@@ -1202,9 +1202,9 @@
   integrity sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==
 
 "@types/react@^16.4.6":
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.6.tgz#fa1de3fe56cc9b6afeddc73d093d7f30fd5e31cc"
-  integrity sha512-bN9qDjEMltmHrl0PZRI4IF2AbB7V5UlRfG+OOduckVnRQ4VzXVSzy/1eLAh778IEqhTnW0mmgL9yShfinNverA==
+  version "16.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.7.tgz#7b1c0223dd5494f9b4501ad2a69aa6acb350a29b"
+  integrity sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -10635,10 +10635,10 @@ react-ga@^2.5.7:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.7.tgz#1c80a289004bf84f84c26d46f3a6a6513081bf2e"
   integrity sha512-UmATFaZpEQDO96KFjB5FRLcT6hFcwaxOmAJZnjrSiFN/msTqylq9G+z5Z8TYzN/dbamDTiWf92m6MnXXJkAivQ==
 
-react-hot-loader@^4.6.5:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.7.2.tgz#54cd99441c2d594bdc58c90673690c245dcfcaff"
-  integrity sha512-kkvGHmvLrbg6RH7svQ28T1swM2JFsHYBRT92xz4k4ubSyPcE2i8YVPQmoKWsDk/zNNpC710M9Md10oZzugecOw==
+react-hot-loader@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.8.0.tgz#0b7c7dd9407415e23eb8246fdd28b0b839f54cb6"
+  integrity sha512-HY9F0vITYSVmXhAR6tPkMk240nxmoH8+0rca9iO2B82KVguiCiBJkieS0Wb4CeSIzLWecYx3iOcq8dcbnp0bxA==
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
@@ -11376,6 +11376,14 @@ scheduler@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
   integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
+  integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
It looks like `react-hot-loader` isn't playing nicely with `navi` (possibly due to the way the pages are created via `createPage`), so this workaround allows us to use HMR without having the entire page refresh on each change (at least until a better solution exists).