### PR TITLE
use the tx manager service to explicitly update provider state

### DIFF
--- a/src/components/ExternalLink.js
+++ b/src/components/ExternalLink.js
@@ -5,7 +5,8 @@ import { ReactComponent as ExternalLinkIcon } from 'images/external-link.svg';
 
 const ExternalLink = ({ address, network }) => (
   <Link fontWeight="400" href={etherscanLink(address, network)} target="_blank">
-    <Address full={address} shorten={true} /> <ExternalLinkIcon />
+    <Address full={address} shorten={true} expandable={false} />
+    <ExternalLinkIcon />
   </Link>
 );
 

--- a/src/components/RatioDisplay.js
+++ b/src/components/RatioDisplay.js
@@ -4,7 +4,7 @@ import { CDP_SAFETY_LEVELS } from 'utils/constants';
 import { Text } from '@makerdao/ui-components-core';
 import { prettifyNumber } from 'utils/ui';
 
-const CDP_SAFETY_COLOR_PALETE = {
+const CDP_SAFETY_COLOR_PALETTE = {
   [CDP_SAFETY_LEVELS.DANGER]: getColor('redVivid'),
   [CDP_SAFETY_LEVELS.NEUTRAL]: getColor('grayLight2'),
   [CDP_SAFETY_LEVELS.SAFE]: getColor('greenVivid')
@@ -24,7 +24,7 @@ export default function RatioDisplay({ ratio, active }) {
   return (
     <Text
       t="p6"
-      color={active ? 'white' : CDP_SAFETY_COLOR_PALETE[safetyLevel]}
+      color={active ? 'white' : CDP_SAFETY_COLOR_PALETTE[safetyLevel]}
     >
       {prettifyNumber(ratio, true)}%
     </Text>

--- a/src/components/SidebarBase.js
+++ b/src/components/SidebarBase.js
@@ -21,8 +21,12 @@ const txAnimation = {
   slide: [{ top: `-100%` }, { top: 0 }]
 };
 
-// todo - far from final
-const TransactionManager = ({ transactions = [], removeTx, network } = {}) => {
+const TransactionManager = ({
+  transactions = [],
+  hideTx,
+  selectors,
+  network
+} = {}) => {
   const [slideStart, slideEnd] = txAnimation.slide;
 
   const [slideAnimation] = useSpring(() => ({
@@ -35,11 +39,11 @@ const TransactionManager = ({ transactions = [], removeTx, network } = {}) => {
 
   return (
     <Box bg="red" mr="s" style={slideAnimation}>
-      {transactions.map(tx => (
+      {selectors.getVisibleTransactions().map(tx => (
         <Card mt="s" key={tx.id}>
           <Flex m="s" flexDirection="column">
             <Text>{tx.message}</Text>
-            <button onClick={() => removeTx(tx.id)}>close</button>
+            <button onClick={() => hideTx(tx.id)}>close</button>
             {tx.hash ? (
               <ExternalLink address={tx.hash} network={network} />
             ) : null}
@@ -85,8 +89,9 @@ function Sidebar() {
     maker,
     transactions,
     newTxListener,
+    hideTx,
+    selectors,
     resetTx,
-    removeTx,
     network
   } = useMaker();
   const { current } = useSidebar();
@@ -170,9 +175,10 @@ function Sidebar() {
   return (
     <Box>
       <TransactionManager
+        selectors={selectors}
         transactions={transactions}
         network={network}
-        removeTx={removeTx}
+        hideTx={hideTx}
       />
       <Grid gridRowGap="s" py="s">
         <Box pr="s">

--- a/src/hooks/useMaker.js
+++ b/src/hooks/useMaker.js
@@ -4,8 +4,15 @@ import { checkEthereumProvider } from 'utils/ethereum';
 import { MakerObjectContext } from 'providers/MakerHooksProvider';
 
 function useMaker() {
-  const { maker, account, transactions, newTxListener, resetTx } =
-    useContext(MakerObjectContext) || {};
+  const {
+    maker,
+    account,
+    transactions,
+    newTxListener,
+    resetTx,
+    removeTx,
+    network
+  } = useContext(MakerObjectContext) || {};
   const [authenticated, setAuthenticated] = useState(false);
 
   useEffect(() => {
@@ -77,7 +84,9 @@ function useMaker() {
     account,
     transactions,
     newTxListener,
-    resetTx
+    resetTx,
+    removeTx,
+    network
   };
 }
 

--- a/src/hooks/useMaker.js
+++ b/src/hooks/useMaker.js
@@ -10,7 +10,8 @@ function useMaker() {
     transactions,
     newTxListener,
     resetTx,
-    removeTx,
+    hideTx,
+    selectors,
     network
   } = useContext(MakerObjectContext) || {};
   const [authenticated, setAuthenticated] = useState(false);
@@ -85,7 +86,8 @@ function useMaker() {
     transactions,
     newTxListener,
     resetTx,
-    removeTx,
+    hideTx,
+    selectors,
     network
   };
 }

--- a/src/providers/MakerHooksProvider.js
+++ b/src/providers/MakerHooksProvider.js
@@ -34,9 +34,21 @@ function MakerHooksProvider({ children, rpcUrl, addresses, network }) {
 
     const txId = id.current++;
 
+    transaction.catch(() =>
+      setTransactions(txs =>
+        txs.map(tx => (tx.id === txId ? { ...tx, state: 'error' } : tx))
+      )
+    );
+
     setTransactions(txs => [
       ...txs,
-      { state: 'initialized', id: txId, message: txMessage, hash: '' }
+      {
+        state: 'initialized',
+        id: txId,
+        message: txMessage,
+        hash: '',
+        hidden: false
+      }
     ]);
 
     maker.service('transactionManager').listen(transaction, {
@@ -60,14 +72,16 @@ function MakerHooksProvider({ children, rpcUrl, addresses, network }) {
     });
   };
 
-  const removeTx = txId => {
-    setTransactions(txs => txs.filter(tx => tx.id !== txId));
+  const hideTx = txId => {
+    setTransactions(txs =>
+      txs.map(tx => (tx.id === txId ? { ...tx, hidden: true } : tx))
+    );
   };
 
-  // todo - far from final
-  const resetTx = transaction => {
-    // todo listen to tx events too
-    setTransactions([]);
+  const getVisibleTransactions = () => transactions.filter(tx => !tx.hidden);
+
+  const selectors = {
+    getVisibleTransactions
   };
 
   return (
@@ -78,8 +92,8 @@ function MakerHooksProvider({ children, rpcUrl, addresses, network }) {
         network,
         transactions,
         newTxListener,
-        resetTx,
-        removeTx
+        hideTx,
+        selectors
       }}
     >
       {children}


### PR DESCRIPTION
this pr has us manage the state of multiple txs in our `MakerHooksProvider`. an other option is to depend completely on the sdk's internal state, but using the manager actually feels ok to me offhand

![tx-manager-ui](https://user-images.githubusercontent.com/24902242/56020485-1eb07a80-5cbc-11e9-88ec-3c5fe9daf524.gif)
