### PR TITLE
move tests into src

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -25,5 +25,11 @@ module.exports = {
   },
   babel: {
     plugins: ['styled-components', 'react-hot-loader/babel']
+  },
+  jest: {
+    configure: {
+      coverageReporters: ['json', 'lcov', 'text-summary'],
+      setupTestFrameworkScriptFile: '<rootDir>/test/setup.js'
+    }
   }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  coverageReporters: ['json', 'lcov', 'text-summary'],
-  collectCoverageFrom: ['src/**/*.js'],
-  roots: ['src', 'test']
-};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "start:https": "HTTPS=true NODE_ENV=development NODE_PATH=src/ craco start",
     "build": "NODE_PATH=src/ craco --max_old_space_size=8192 build",
     "precommit": "lint-staged",
-    "test": "NODE_PATH=src/ jest",
+    "test": "NODE_PATH=src/ craco test",
     "ci": "./node_modules/@makerdao/testchain/scripts/launch -s mcd-step-4 --fast --ci jest --coverage",
     "now-build": "yarn build",
     "remove-sourcemaps": "rm -rf build/static/js/*.map"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "build": "NODE_PATH=src/ craco --max_old_space_size=8192 build",
     "precommit": "lint-staged",
     "test": "NODE_PATH=src/ craco test",
-    "ci": "./node_modules/@makerdao/testchain/scripts/launch -s mcd-step-4 --fast --ci jest --coverage",
+    "ci": "./node_modules/@makerdao/testchain/scripts/launch -s mcd-step-4 --fast --ci yarn test --coverage",
     "now-build": "yarn build",
     "remove-sourcemaps": "rm -rf build/static/js/*.map"
   },

--- a/src/hooks/__tests__/useMaker.spec.js
+++ b/src/hooks/__tests__/useMaker.spec.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { render, cleanup } from 'react-testing-library';
 import waitForExpect from 'wait-for-expect';
 
-import MakerProvider from '../src/providers/MakerProvider';
-import useMaker from '../src/hooks/useMaker';
-import config from '../src/references/config.json';
+import MakerProvider from '../../providers/MakerProvider';
+import useMaker from '../useMaker';
+import config from '../../references/config.json';
 
 // This helper component allows us to call the hook in a component context.
 function TestHook({ callback }) {
@@ -28,6 +28,8 @@ beforeAll(() => {
 afterEach(cleanup);
 
 // we allow up to 10 seconds for this
+// test will throw a warning, see here for explanation:
+// https://github.com/testing-library/react-testing-library/issues/281#issuecomment-480349256
 test('maker is properly instantiated and authenticated within the maker provider', async () => {
   expect(useMakerHookValue.authenticated).toBe(false);
   await waitForExpect(() => {

--- a/src/utils/__tests__/ui.spec.js
+++ b/src/utils/__tests__/ui.spec.js
@@ -1,9 +1,5 @@
-import {
-  fullActivityString,
-  firstLetterLowercase,
-  formatDate
-} from '../src/utils/ui';
-import { mockHistoryDataFromSDK } from '../src/reducers/cdps';
+import { fullActivityString, firstLetterLowercase, formatDate } from '../ui';
+import { mockHistoryDataFromSDK } from '../../reducers/cdps';
 
 test('fullActivityString', () => {
   expect(fullActivityString(mockHistoryDataFromSDK[2])).toBe(
@@ -16,5 +12,8 @@ test('firstLetterLowercase', () => {
 });
 
 test('formatDate', () => {
-  expect(formatDate(new Date(0))).toBe('Jan 1, 1970');
+  const date = new Date(0);
+  expect(formatDate(date)).toBe(
+    date.getTimezoneOffset() > 0 ? 'Dec 31, 1969' : 'Jan 1, 1970'
+  );
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,3 +1,0 @@
-test('self-test', () => {
-  expect(11).toEqual(11);
-});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,17 @@
+// this is just a little hack to silence a warning that we'll get until react
+// fixes this: https://github.com/facebook/react/pull/14853
+//
+// https://github.com/testing-library/react-testing-library/issues/281
+const originalError = console.error;
+beforeAll(() => {
+  console.error = (...args) => {
+    if (/Warning.*not wrapped in act/.test(args[0])) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});


### PR DESCRIPTION
under `__tests__` directories, following the convention seen in some popular repos ([e.g.](https://github.com/facebook/react/tree/master/packages/react-dom/src/__tests__))

also use `craco test` so that we're using the same babel configuration in tests as we do in development

also suppress the "not wrapped in act" warning