### PR TITLE
Use custom hooks to encapsulate state update logic

### DIFF
--- a/src/components/Sidebars/Global.js
+++ b/src/components/Sidebars/Global.js
@@ -2,18 +2,18 @@ import React, { useMemo } from 'react';
 import SidebarFeeds from 'components/SidebarFeeds';
 import SidebarSystem from 'components/SidebarSystem';
 import { Box, Grid } from '@makerdao/ui-components-core';
-import { getAllFeeds } from 'reducers/feeds';
-import useStore from 'hooks/useStore';
+import useFeeds from 'hooks/useFeeds';
+import useSystemInfo from 'hooks/useSystemInfo';
 
 const SidebarGlobalPanel = () => {
-  const [{ system, feeds }] = useStore();
-  return useMemo(() => {
-    const uniqueFeeds = getAllFeeds(feeds, [feeds]);
+  const feeds = useFeeds();
+  const system = useSystemInfo();
 
+  return useMemo(() => {
     return (
       <Box>
         <Grid gridRowGap="s">
-          <SidebarFeeds feeds={uniqueFeeds} />
+          <SidebarFeeds feeds={feeds} />
           <SidebarSystem system={system} />
         </Grid>
         <Dev />
@@ -25,20 +25,20 @@ const SidebarGlobalPanel = () => {
 export default SidebarGlobalPanel;
 
 const Dev = () => {
-  const [, dispatch] = useStore();
+  // const [, dispatch] = useStore();
 
-  window.randomizeEthPrice = () => {
-    const num = Math.round(Math.random() * 50) + 100;
-    const value = num.toString() + '000000000000000000000000000';
-    dispatch({
-      type: 'watcherUpdates',
-      payload: [{ type: 'ilk.ETH-A.priceWithSafetyMargin', value }]
-    });
-  };
+  // window.randomizeEthPrice = () => {
+  //   const num = Math.round(Math.random() * 50) + 100;
+  //   const value = num.toString() + '000000000000000000000000000';
+  //   dispatch({
+  //     type: 'watcherUpdates',
+  //     payload: [{ type: 'ilk.ETH-A.priceWithSafetyMargin', value }]
+  //   });
+  // };
 
-  window.updateCdps = () => {
-    dispatch({ type: 'cdps/FETCHED_CDPS', payload: { cdps: [] } });
-  };
+  // window.updateCdps = () => {
+  //   dispatch({ type: 'cdps/FETCHED_CDPS', payload: { cdps: [] } });
+  // };
 
   return null;
 };

--- a/src/hooks/useFeeds.js
+++ b/src/hooks/useFeeds.js
@@ -1,0 +1,33 @@
+import { useState, useEffect, useMemo } from 'react';
+import useMaker from 'hooks/useMaker';
+import uniqBy from 'lodash/uniqBy';
+
+const useFeeds = () => {
+  const { maker } = useMaker();
+  const [cdpTypes, setCdpTypes] = useState([]);
+
+  // TODO: Hook into CdpTypeService price updates via SDK
+  useEffect(() => {
+    (async () => {
+      const types = maker.service('mcd:cdpType').cdpTypes;
+      console.debug('[useFeeds] Awaiting prefetch');
+      await Promise.all(types.map(type => type.prefetch()));
+      console.debug('[useFeeds] Got types:', types);
+      setCdpTypes(types);
+    })();
+  }, [maker]);
+
+  const uniqueUsdFeeds = useMemo(() => {
+    return uniqBy(cdpTypes, 'price.symbol').reduce((acc, cdpType) => {
+      if (cdpType.price.numerator.symbol !== 'USD') return acc;
+      return acc.concat({
+        pair: cdpType.price.symbol,
+        value: cdpType.price
+      });
+    }, []);
+  }, [cdpTypes]);
+
+  return uniqueUsdFeeds;
+};
+
+export default useFeeds;

--- a/src/hooks/useManagedCdps.js
+++ b/src/hooks/useManagedCdps.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import useMaker from 'hooks/useMaker';
+
+const useManagedCdps = address => {
+  const { account, maker } = useMaker();
+  const [managedCdps, setManagedCdps] = useState([]);
+
+  // TODO: Hook into managed CDP state updates via SDK
+  useEffect(() => {
+    (async () => {
+      if (!address && account) address = await maker.currentProxy();
+      if (!address) return;
+      console.debug('[useManagedCdps] Using address:', address);
+      const cdps = await maker.service('mcd:cdpManager').getCdpIds(address);
+      console.debug('[useManagedCdps] Got cdps:', cdps);
+      const getCdps = await Promise.all(
+        cdps.map(cdp => maker.service('mcd:cdpManager').getCdp(cdp.id, cdp.ilk))
+      );
+      console.debug('[useManagedCdps] Got managed CDPs:', getCdps);
+      setManagedCdps(getCdps);
+    })();
+  }, [maker, account, address]);
+
+  return managedCdps;
+};
+
+export default useManagedCdps;

--- a/src/hooks/useSystemInfo.js
+++ b/src/hooks/useSystemInfo.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+import useStore from 'hooks/useStore';
+// import useMaker from 'hooks/useMaker';
+
+const useSystemInfo = () => {
+  // const { maker } = useMaker();
+  const [{ system }] = useStore();
+  const [systemInfo, setSystemInfo] = useState([]);
+
+  // TODO: Hook into SystemDataService state updates via SDK
+  useEffect(() => {
+    // console.debug('[useSystemInfo] useEffect', system);
+    setSystemInfo(system);
+    // return maker.service('mcd:systemData').onChange();
+  }, [system]);
+
+  return systemInfo;
+};
+
+export default useSystemInfo;

--- a/src/reducers/feeds.js
+++ b/src/reducers/feeds.js
@@ -1,6 +1,5 @@
 import produce from 'immer';
 import ilkList from 'references/ilkList';
-import uniqBy from 'lodash/uniqBy';
 import BigNumber from 'bignumber.js';
 import { fromWei, fromRay, fromRad, sub, mul, RAY } from 'utils/units';
 
@@ -49,17 +48,6 @@ export function getIlkData(feeds, ilkKey) {
     stabilityFee: ilkData[DUTY],
     ilkDebtAvailable: ilkData[ILK_DEBT_AVAILABLE]
   };
-}
-
-export function getAllFeeds(feeds) {
-  return uniqBy(feeds, 'gem').reduce((acc, cdpType) => {
-    // this will get usd feeds only
-    if (!cdpType[FEED_VALUE_USD]) return acc;
-    return acc.concat({
-      pair: `${[cdpType.currency.symbol]}/USD`,
-      value: cdpType[FEED_VALUE_USD]
-    });
-  }, []);
 }
 
 const initialState = ilkList.map(ilk => ({ ...ilk, ...defaultIlkState }));


### PR DESCRIPTION
First pass at one possible way we could use state (initial state and subsequent updates via subscriptions) from the SDK using custom hooks. 

Note: This uses the [non-async-mcdp](https://github.com/makerdao/dai.js/tree/non-async-mcdp) dai.js branch to make use of prefetch and the non-async getters.