### PR TITLE
Cdp 436 decimals

### DIFF
--- a/src/reducers/feeds.js
+++ b/src/reducers/feeds.js
@@ -83,10 +83,6 @@ function convert(valueType, value, decimals) {
       return fromRad(value).toFixed(0);
     case MAX_AUCTION_LOT_SIZE:
     case ADAPTER_BALANCE:
-      console.log(
-        'fromDecimals(value, decimals).toFixed(5)',
-        fromDecimals(value, decimals).toFixed(5)
-      );
       return fromDecimals(value, decimals).toFixed(5);
     case LIQUIDATION_RATIO:
       return fromRay(value)
@@ -106,7 +102,7 @@ const reducer = produce((draft, { type, value }) => {
   const [label, key, valueType] = type.split('.');
   const ilk = ilkList.find(i => i.key === key);
   let decimals = 18;
-  if (ilk) decimals = ilk.decimals;
+  if (ilk && ilk.decimals) decimals = ilk.decimals;
   if (label === 'ilk') {
     draft.find(f => f.key === key)[valueType] = convert(
       valueType,

--- a/src/reducers/math.js
+++ b/src/reducers/math.js
@@ -18,6 +18,7 @@ import * as math from '@makerdao/dai-plugin-mcd/dist/math';
 import compact from 'lodash/compact';
 import { MDAI } from '@makerdao/dai-plugin-mcd';
 import { USD } from '../maker';
+import ilkList from 'references/ilkList';
 
 const mathReducer = produce((draft, action) => {
   if (action.type === 'CLEAR_CONTRACT_STATE') draft.raw = {};
@@ -94,13 +95,16 @@ const mathReducer = produce((draft, action) => {
               par
             );
             if (adapterBalance && price) {
-              return math.collateralValue(
-                math.collateralAmount(
-                  getCurrency({ ilk: feed.key }),
-                  adapterBalance
-                ),
-                price
+              let colAmount = math.collateralAmount(
+                getCurrency({ ilk: feed.key }),
+                adapterBalance
               );
+              const ilk = ilkList.find(i => i.key === feed.key);
+              let decimals = 18;
+              if (ilk && ilk.decimals) decimals = ilk.decimals;
+              const currency = getCurrency({ ilk: feed.key });
+              colAmount = currency(adapterBalance, -decimals);
+              return math.collateralValue(colAmount, price);
             }
           });
           const combinedColVal = compact(colVals).reduce(

--- a/src/references/ilkList.js
+++ b/src/references/ilkList.js
@@ -49,6 +49,7 @@ export default [
     symbol: 'DGD-A',
     key: 'DGD-A',
     gem: 'DGD',
-    currency: DGD
+    currency: DGD,
+    decimals: 9
   }
 ];

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -17,3 +17,7 @@ export function fromRay(value) {
 export function fromRad(value) {
   return BigNumber(value).shiftedBy(-45);
 }
+
+export function fromDecimals(value, decimals = 18) {
+  return BigNumber(value).shiftedBy(-decimals);
+}


### PR DESCRIPTION
Quick fix to account for non-standard token decimals when reading the adapter balance.
I think the ideal solution would be to have the currency object be aware of how many decimals it has, and then have a function to shift that many decimals.  Has this been discussed before?  Currently it seems like only the token service is aware of token decimals.