### PR TITLE
Hardware wallet pagination fix

### DIFF
--- a/src/components/HardwareAccountSelect.js
+++ b/src/components/HardwareAccountSelect.js
@@ -34,6 +34,7 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
 
   useEffect(() => {
     connect().then(address => {
+      console.log('connect resolved');
       confirmAddress(address);
       onClose();
     }, onClose);

--- a/src/components/HardwareAccountSelect.js
+++ b/src/components/HardwareAccountSelect.js
@@ -15,30 +15,29 @@ import { getColor } from 'styles/theme';
 import { CopyBtn, CopyBtnIcon } from './AddressTable';
 import { ReactComponent as Cross } from 'images/cross.svg';
 import { AccountTypes } from 'utils/constants';
+import { LEDGER_LIVE_PATH } from './LedgerType';
 
 const ACCOUNTS_PER_PAGE = 5;
 const ACCOUNTS_TO_FETCH = 25;
 
-function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
+function HardwareAccountSelect({ type, path, onClose }) {
   const [page, setPage] = useState(0);
   const [selectedAddress, setSelectedAddress] = useState(null);
-  const accountsToFetch =
-    type === AccountTypes.LEDGER ? ACCOUNTS_PER_PAGE : ACCOUNTS_TO_FETCH;
+  const numAccountsPerFetch =
+    (type === AccountTypes.LEDGER && path === LEDGER_LIVE_PATH) ? ACCOUNTS_PER_PAGE : ACCOUNTS_TO_FETCH;
   const {
     fetchMore,
     connect,
     accounts,
     pickAccount,
     fetching
-  } = useHardwareWallet({ type, accountsLength: accountsToFetch, path });
+  } = useHardwareWallet({ type, accountsLength: numAccountsPerFetch, path });
 
   useEffect(() => {
-    connect().then(address => {
-      console.log('connect resolved');
-      confirmAddress(address);
+    connect().then(() => {
       onClose();
     }, onClose);
-  }, [confirmAddress, connect, onClose]);
+  }, [connect, onClose]);
 
   const toPage = useCallback(
     async page => {
@@ -49,7 +48,7 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
   );
 
   const onConfirm = () => {
-    pickAccount(selectedAddress, page);
+    pickAccount(selectedAddress, page, numAccountsPerFetch, ACCOUNTS_PER_PAGE, type);
   };
 
   const start = page * ACCOUNTS_PER_PAGE;

--- a/src/components/HardwareAccountSelect.js
+++ b/src/components/HardwareAccountSelect.js
@@ -24,9 +24,13 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
   const [selectedAddress, setSelectedAddress] = useState(null);
   const accountsToFetch =
     type === AccountTypes.LEDGER ? ACCOUNTS_PER_PAGE : ACCOUNTS_TO_FETCH;
-  const { fetch, connect, accounts, pickAccount, fetching } = useHardwareWallet(
-    { type, accountsLength: accountsToFetch, path }
-  );
+  const {
+    fetchMore,
+    connect,
+    accounts,
+    pickAccount,
+    fetching
+  } = useHardwareWallet({ type, accountsLength: accountsToFetch, path });
 
   useEffect(() => {
     connect().then(address => {
@@ -37,13 +41,10 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
 
   const toPage = useCallback(
     async page => {
-      if (accounts.length - page * ACCOUNTS_PER_PAGE <= 0) {
-        const offset = accounts.length / (page * ACCOUNTS_PER_PAGE);
-        await fetch({ offset });
-      }
+      if (accounts.length <= page * ACCOUNTS_PER_PAGE) await fetchMore();
       setPage(page);
     },
-    [accounts, fetch]
+    [accounts, fetchMore]
   );
 
   const selectAddress = useCallback(

--- a/src/components/HardwareAccountSelect.js
+++ b/src/components/HardwareAccountSelect.js
@@ -47,16 +47,9 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
     [accounts, fetchMore]
   );
 
-  const selectAddress = useCallback(
-    address => {
-      setSelectedAddress(address);
-    },
-    [setSelectedAddress]
-  );
-
-  const onConfirm = useCallback(() => {
-    pickAccount(selectedAddress);
-  }, [pickAccount, selectedAddress]);
+  const onConfirm = () => {
+    pickAccount(selectedAddress, page);
+  };
 
   const start = page * ACCOUNTS_PER_PAGE;
   const renderedAccounts = accounts.slice(start, start + ACCOUNTS_PER_PAGE);
@@ -122,7 +115,7 @@ function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
                         name="address"
                         value={index}
                         checked={address === selectedAddress}
-                        onChange={() => selectAddress(address)}
+                        onChange={() => setSelectedAddress(address)}
                       />
                     </Flex>
                   </td>

--- a/src/components/HardwareAccountSelect.js
+++ b/src/components/HardwareAccountSelect.js
@@ -20,7 +20,7 @@ import { LEDGER_LIVE_PATH } from './LedgerType';
 const ACCOUNTS_PER_PAGE = 5;
 const ACCOUNTS_TO_FETCH = 25;
 
-function HardwareAccountSelect({ type, path, onClose }) {
+function HardwareAccountSelect({ type, path, onClose, confirmAddress }) {
   const [page, setPage] = useState(0);
   const [selectedAddress, setSelectedAddress] = useState(null);
   const numAccountsPerFetch =
@@ -48,7 +48,7 @@ function HardwareAccountSelect({ type, path, onClose }) {
   );
 
   const onConfirm = () => {
-    pickAccount(selectedAddress, page, numAccountsPerFetch, ACCOUNTS_PER_PAGE, type);
+    pickAccount(selectedAddress, page, numAccountsPerFetch, ACCOUNTS_PER_PAGE, confirmAddress);
   };
 
   const start = page * ACCOUNTS_PER_PAGE;

--- a/src/components/LedgerType.js
+++ b/src/components/LedgerType.js
@@ -15,7 +15,7 @@ const StyledLedgerLogo = styled(LedgerLogo)`
   margin-bottom: -5px;
 `;
 
-const LEDGER_LIVE_PATH = "44'/60'/0'";
+export const LEDGER_LIVE_PATH = "44'/60'/0'";
 const LEDGER_LEGACY_PATH = "44'/60'/0'/0";
 
 function LedgerType({ onClose, onPathSelect }) {

--- a/src/hooks/useHardwareWallet.js
+++ b/src/hooks/useHardwareWallet.js
@@ -3,7 +3,6 @@ import useMaker from 'hooks/useMaker';
 import useModal from 'hooks/useModal';
 import { AccountTypes } from 'utils/constants';
 import { addMkrAndEthBalance } from 'utils/ethereum';
-import { mixpanelIdentify } from 'utils/analytics';
 
 const TREZOR_PATH = "44'/60'/0'/0/0";
 
@@ -163,14 +162,22 @@ function useHardwareWallet({
     });
   }, [accountsLength, maker, path, type, state.accounts.length]);
 
-  function pickAccount(address, page, numAccountsPerFetch, numAccountsPerPage, type) {
-    mixpanelIdentify(address, type);
-    const fetchNumber = Math.floor( page * numAccountsPerPage / numAccountsPerFetch);
-    for (let i = 0; i < state.totalNumFetches; i++){
+  function pickAccount(
+    address,
+    page,
+    numAccountsPerFetch,
+    numAccountsPerPage,
+    confirmAddress
+  ) {
+    const fetchNumber = Math.floor(
+      (page * numAccountsPerPage) / numAccountsPerFetch
+    );
+    for (let i = 0; i < state.totalNumFetches; i++) {
       //error out unused callbacks
       if (i !== fetchNumber) state.chooseCallbacks[i]('error');
     }
-    return state.chooseCallbacks[fetchNumber](null, address);
+    state.chooseCallbacks[fetchNumber](null, address);
+    setTimeout(()=> confirmAddress({address}), 1);
   }
 
   return {

--- a/src/hooks/useHardwareWallet.js
+++ b/src/hooks/useHardwareWallet.js
@@ -34,8 +34,6 @@ const reducer = (state, action) => {
       return { ...state, fetching: false };
     case 'fetch-success': {
       const totalNumFetches = state.totalNumFetches + 1;
-      console.log('totalNumFetches - 1', totalNumFetches - 1);
-      console.log('payload.chooseCallback', payload.chooseCallback);
       return {
         ...state,
         totalNumFetches,
@@ -172,8 +170,6 @@ function useHardwareWallet({
       //error out unused callbacks
       if (i !== fetchNumber) state.chooseCallbacks[i]('error');
     }
-    console.log('state.chooseCallbacks', state.chooseCallbacks);
-    console.log('page', page);
     return state.chooseCallbacks[fetchNumber](null, address);
   }
 

--- a/src/hooks/useHardwareWallet.js
+++ b/src/hooks/useHardwareWallet.js
@@ -50,7 +50,7 @@ const reducer = (state, action) => {
         accounts: [...state.accounts, ...payload.accounts],
         chooseCallbacks: {
           ...state.chooseCallbacks,
-          [pagesFetched]: payload.chooseCallback
+          [pagesFetched-1]: payload.chooseCallback
         }
       };
     }
@@ -135,7 +135,7 @@ function useHardwareWallet({
       choose: async (addresses, chooseCallback) => {
         const accounts = await computeAddressBalances(addresses);
         dispatch({ type: 'connect-success', payload: { chooseCallback } });
-        dispatch({ type: 'fetch-success', payload: { accounts, offset: 0 } });
+        dispatch({ type: 'fetch-success', payload: { chooseCallback, accounts, offset: 0 } });
       }
     });
   }, [accountsLength, maker, path, type]);

--- a/src/hooks/useHardwareWallet.js
+++ b/src/hooks/useHardwareWallet.js
@@ -28,19 +28,9 @@ const reducer = (state, action) => {
     case 'connect-start':
       return initialState;
     case 'fetch-start':
-      return {
-        ...state,
-        fetching: true
-      };
+      return { ...state, fetching: true };
     case 'connect-success':
-      return {
-        ...state,
-        fetching: false,
-        chooseCallbacks: {
-          ...state.chooseCallbacks,
-          0: payload.chooseCallback
-        }
-      };
+      return { ...state, fetching: false };
     case 'fetch-success': {
       const pagesFetched = state.pagesFetched + 1;
       return {
@@ -50,7 +40,7 @@ const reducer = (state, action) => {
         accounts: [...state.accounts, ...payload.accounts],
         chooseCallbacks: {
           ...state.chooseCallbacks,
-          [pagesFetched-1]: payload.chooseCallback
+          [pagesFetched - 1]: payload.chooseCallback
         }
       };
     }
@@ -134,8 +124,11 @@ function useHardwareWallet({
       accountsLength,
       choose: async (addresses, chooseCallback) => {
         const accounts = await computeAddressBalances(addresses);
-        dispatch({ type: 'connect-success', payload: { chooseCallback } });
-        dispatch({ type: 'fetch-success', payload: { chooseCallback, accounts, offset: 0 } });
+        dispatch({ type: 'connect-success' });
+        dispatch({
+          type: 'fetch-success',
+          payload: { chooseCallback, accounts, offset: 0 }
+        });
       }
     });
   }, [accountsLength, maker, path, type]);

--- a/src/hooks/useHardwareWallet.js
+++ b/src/hooks/useHardwareWallet.js
@@ -163,6 +163,9 @@ function useHardwareWallet({
   }, [accountsLength, maker, path, type, state.accounts.length]);
 
   function pickAccount(address, page) {
+    for (let i = 0; i < state.pagesFetched; i++){
+      if (i !== page) state.chooseCallbacks[i]('error');
+    }
     return state.chooseCallbacks[page](null, address);
   }
 


### PR DESCRIPTION
@tyler17 let me know if this works for you. The basic idea is that useHardwareWallet keeps a reference to the callback from `choose` for each time it calls `addAccount` for a page of results, and when an address is chosen, uses the callback corresponding to the current page.

Sorry if there are any bugs; I am working while traveling and don't have my Ledger with me. Better just to look at the [second commit](https://github.com/makerdao/mcd-cdp-portal/pull/162/commits/9d86d78f6ec249dc017a367df411edcdb6300f44) when reviewing since the first one is just reverting a revert.