### PR TITLE
Fix borrow calculator crashes

### DIFF
--- a/src/components/Marketing/Calculators.js
+++ b/src/components/Marketing/Calculators.js
@@ -10,6 +10,7 @@ import { ReactComponent as TusdIcon } from 'images/oasis-tokens/tusd.svg';
 import { ReactComponent as EthIcon } from 'images/oasis-tokens/eth.svg';
 import { ReactComponent as UsdcIcon } from 'images/oasis-tokens/usdc.svg';
 import { ReactComponent as WbtcIcon } from 'images/oasis-tokens/wbtc.svg';
+import { ReactComponent as DefaultIcon } from 'images/oasis-tokens/default.svg';
 import { ReactComponent as CaratDown } from 'images/carat-down-filled.svg';
 import { ReactComponent as DaiImg } from 'images/dai-color.svg';
 
@@ -390,7 +391,10 @@ const BorrowCalculator = props => {
             items={gems.map(gem => ({
               value: gem.symbol,
               render: () => (
-                <DropdownItem img={<gem.Icon width="28.33" height="28.33" />}>
+                <DropdownItem img={gem.Icon ?
+                  <gem.Icon width="28.33" height="28.33" /> :
+                  <DefaultIcon width="28.33" height="28.33"/>
+                }>
                   {gem.text || gem.symbol}
                 </DropdownItem>
               )

--- a/src/components/Marketing/Calculators.js
+++ b/src/components/Marketing/Calculators.js
@@ -332,41 +332,44 @@ const BorrowCalculator = props => {
       amountStart: 25
     },
     'BAT-A': {
+      text: 'BAT',
       Icon: BatIcon,
       colRatio: 200,
       amountRange: [200, 70000],
       amountStart: 600
     },
     'USDC-A': {
+      text: 'USDC',
       Icon: UsdcIcon,
       colRatio: 120,
       amountRange: [200, 70000],
       amountStart: 5000
     },
     'WBTC-A': {
+      text: 'WBTC',
       Icon: WbtcIcon,
       colRatio: 200,
       amountRange: [0.1, 35],
       amountStart: 0.5
     },
     'TUSD-A': {
+      text: 'TUSD',
       Icon: TusdIcon,
       colRatio: 120,
       amountRange: [200, 70000],
       amountStart: 5000
     }
   };
-
   const gems = cdpTypesList
     .map((cdpTypeName, index) => ({
       name: cdpTypeName,
       price: prices && prices[index].toBigNumber()
     }))
-    .filter(cdpType => cdpType.name.endsWith('-A')) // only first cdp type per collateral
+    .filter(cdpType => cdpTypesMetaData[cdpType.name])
     .map(cdpType => ({
       ...cdpType,
       ...cdpTypesMetaData[cdpType.name],
-      symbol: cdpType.name.replace('-A', '')
+      symbol: cdpType.name
     }));
 
   const [selectedSymbol, setSelectedSymbol] = useState(gems[0].symbol);
@@ -391,10 +394,15 @@ const BorrowCalculator = props => {
             items={gems.map(gem => ({
               value: gem.symbol,
               render: () => (
-                <DropdownItem img={gem.Icon ?
-                  <gem.Icon width="28.33" height="28.33" /> :
-                  <DefaultIcon width="28.33" height="28.33"/>
-                }>
+                <DropdownItem
+                  img={
+                    gem.Icon ? (
+                      <gem.Icon width="28.33" height="28.33" />
+                    ) : (
+                      <DefaultIcon width="28.33" height="28.33" />
+                    )
+                  }
+                >
                   {gem.text || gem.symbol}
                 </DropdownItem>
               )
@@ -409,7 +417,9 @@ const BorrowCalculator = props => {
             <Position position="absolute" bottom="37px" right="0">
               <CapsText textAlign="right">
                 {collateralAmounts[selectedSymbol]}
-                <span style={{ marginLeft: '3px' }}>{selectedGem.symbol}</span>
+                <span style={{ marginLeft: '3px' }}>
+                  {selectedGem.symbol.split('-')[0]}
+                </span>
               </CapsText>
             </Position>
             <Slider

--- a/src/images/oasis-tokens/default.svg
+++ b/src/images/oasis-tokens/default.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M35 70C54.33 70 70 54.33 70 35C70 15.67 54.33 0 35 0C15.67 0 0 15.67 0 35C0 54.33 15.67 70 35 70Z" style="fill: rgb(229, 231, 237);"/>
+</svg>


### PR DESCRIPTION
Fix borrow calculator crashes:

- When missing an Icon.
- When a new collateral type is not explicitly set up in the calculator.

It also now enables to set up collateral types besides type-A.