### PR TITLE
Update useCdpTypes.js

### DIFF
--- a/src/hooks/useCdpTypes.js
+++ b/src/hooks/useCdpTypes.js
@@ -14,8 +14,9 @@ export default function useCdpTypes() {
 
   const cdpTypesWithNonZeroDebtCeilings = Object.entries(ceilings).reduce(
     (acc, [type, ceiling]) => {
-      if (ceiling.gt(0)) return [...acc, type];
-      return acc;
+      //if (ceiling.gt(0)) return [...acc, type];
+      //return acc;
+      return [...acc, type];
     },
     []
   );


### PR DESCRIPTION
Remove the 0 debt ceiling check to ensure usdc vaults show. full fix still to come to handle non-activated vaults.